### PR TITLE
Use valid and correct KEYWORD_TOKENTYPEs in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
 MCP466_DigitalPot	KEYWORD1
 mcpWrite	KEYWORD2
-mcpRead	KEYWORD3
-mcpUp	KEYWORD4
-mcpDown	KEYWORD5
+mcpRead	KEYWORD2
+mcpUp	KEYWORD2
+mcpDown	KEYWORD2


### PR DESCRIPTION
Use of the undocumented KEYWORD4 KEYWORD_TOKENTYPE causes the keyword to be colored as an inline comment in Arduino IDE 1.6.4 and older, and as the default coloration used for unrecognized identifiers in newer IDE versions.

Use of the undocumented KEYWORD5 KEYWORD_TOKENTYPE causes the keyword to be colored as a hyperlink in Arduino IDE 1.6.4 and older, and as the default coloration used for unrecognized identifiers in newer IDE versions.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype